### PR TITLE
Разработка vpn бота с нуля

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -26,7 +26,9 @@ from bot.handlers.main import (
     cancel_conversation,
     SELECTING_PLAN,
     SELECTING_PAYMENT_METHOD,
-    WAITING_PAYMENT
+    WAITING_PAYMENT,
+    select_protocol,
+    protocol_selected
 )
 from bot.handlers.admin import (
     admin_panel,
@@ -53,7 +55,11 @@ def create_application() -> Application:
         entry_points=[CallbackQueryHandler(show_plans, pattern='^buy_vpn$')],
         states={
             SELECTING_PLAN: [
-                CallbackQueryHandler(select_payment_method, pattern='^plan_'),
+                CallbackQueryHandler(select_protocol, pattern='^plan_'),
+                CallbackQueryHandler(main_menu, pattern='^main_menu$')
+            ],
+            SELECTING_PROTOCOL: [
+                CallbackQueryHandler(protocol_selected, pattern='^protocol_'),
                 CallbackQueryHandler(main_menu, pattern='^main_menu$')
             ],
             SELECTING_PAYMENT_METHOD: [

--- a/bot/utils/helpers.py
+++ b/bot/utils/helpers.py
@@ -19,10 +19,41 @@ def generate_referral_code(length: int = 8) -> str:
     return ''.join(random.choice(chars) for _ in range(length))
 
 
-def generate_vpn_config(user_id: int, server_url: str) -> str:
-    """Generate VPN configuration for user"""
-    # This is a simplified example. In real implementation,
-    # you would integrate with your VPN server API
+def generate_openvpn_config(user_id: int, server_url: str) -> str:
+    """Generate OpenVPN configuration for user (simplified example)"""
+    # В реальной реализации интегрировать с сервером OpenVPN
+    return f"""
+client
+proto udp
+remote {server_url} 1194
+resolv-retry infinite
+nobind
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-CBC
+auth SHA256
+verb 3
+<key>
+USER_PRIVATE_KEY_{user_id}
+</key>
+<cert>
+USER_CERT_{user_id}
+</cert>
+<ca>
+CA_CERT_HERE
+</ca>
+<tls-auth>
+TLS_AUTH_KEY_HERE
+</tls-auth>
+key-direction 1
+    """
+
+def generate_vpn_config(user_id: int, server_url: str, protocol: str = 'wireguard') -> str:
+    """Generate VPN configuration for user (WireGuard or OpenVPN)"""
+    if protocol == 'openvpn':
+        return generate_openvpn_config(user_id, server_url)
+    # По умолчанию WireGuard
     config_template = f"""[Interface]
 PrivateKey = {generate_private_key()}
 Address = 10.0.0.{user_id % 254 + 1}/32

--- a/locales/ru.py
+++ b/locales/ru.py
@@ -129,6 +129,11 @@ MESSAGES = {
     'btn_admin_keys': "🔑 VPN ключи",
     'btn_admin_stats': "📊 Статистика",
     'btn_admin_broadcast': "📢 Рассылка",
+
+    'choose_protocol': "Выберите протокол VPN:",
+    'btn_wireguard': "WireGuard",
+    'btn_openvpn': "OpenVPN",
+    'protocol_selected': "Выбран протокол: {protocol}\nТеперь выберите способ оплаты.",
 }
 
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add support for selecting WireGuard or OpenVPN protocol during VPN purchase to enhance user choice and fulfill the initial request.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
After a user selects a subscription plan, they are now prompted to choose between WireGuard and OpenVPN before proceeding to payment. This includes basic OpenVPN config generation.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-477e19c9-bded-44cb-b8c3-a6ffdb69c095) · [Cursor](https://cursor.com/background-agent?bcId=bc-477e19c9-bded-44cb-b8c3-a6ffdb69c095)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)